### PR TITLE
Fix Issue with Renaming Instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Security -- in case of vulnerabilities.
 -->
 
+## [1.2.1]
+
+### Fixed
+
+- Sometimes the incorrect instrument can appear to be renamed if a saved instrument is renamed
+
 ## [1.2.0]
 
 ### Changed
@@ -286,7 +292,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Feature to retrieve TSP-Link network details
 
 <!-- Version Comparison Links -->
-[Unreleased]: https://github.com/tektronix/tsp-toolkit/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/tektronix/tsp-toolkit/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/tektronix/tsp-toolkit/releases/tag/v1.2.1
 [1.2.0]: https://github.com/tektronix/tsp-toolkit/releases/tag/v1.2.0
 [1.1.1]: https://github.com/tektronix/tsp-toolkit/releases/tag/v1.1.1
 [1.1.0]: https://github.com/tektronix/tsp-toolkit/releases/tag/v1.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "tsp-toolkit",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tsp-toolkit",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@tektronix/keithley_instrument_libraries": "0.18.4",
@@ -2947,9 +2947,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.88",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.88.tgz",
-            "integrity": "sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==",
+            "version": "1.5.90",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.90.tgz",
+            "integrity": "sha512-C3PN4aydfW91Natdyd449Kw+BzhLmof6tzy5W1pFC5SpQxVXT+oyiyOG9AgYYSN9OdA/ik3YkCrpwqI8ug5Tug==",
             "dev": true,
             "license": "ISC"
         },
@@ -3834,9 +3834,9 @@
             "license": "MIT"
         },
         "node_modules/fastq": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
-            "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+            "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "Tektronix",
     "displayName": "Keithley TSP Toolkit",
     "description": "VSCode extension for Keithley Instruments' Test Script Processor",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "icon": "./resources/TSP_Toolkit_128x128.png",
     "galleryBanner": {
         "color": "#EEEEEE",

--- a/src/instrumentExplorer.ts
+++ b/src/instrumentExplorer.ts
@@ -183,7 +183,6 @@ export class InstrumentsExplorer implements vscode.Disposable {
                 func: "InstrumentsExplorer.rename()",
             })
             item.name = name
-            this.treeDataProvider?.addOrUpdateInstrument(item)
             this.treeDataProvider?.doWithConfigWatcherOff(() => {
                 this.treeDataProvider?.updateSaved(item).catch(() => {})
             })


### PR DESCRIPTION
Sometimes if an instrument is renamed, an instrument other than the target instrument will appear to be renamed instead. This rename doesn't seem to be persistent across reboots of VSCode.

In this PR I fix this by doing the following:
- Remove unnecessary update calls from the rename function in `InstrumentsExplorer`